### PR TITLE
5 teensy amplitude return

### DIFF
--- a/teensy_lockin.ino
+++ b/teensy_lockin.ino
@@ -565,6 +565,6 @@ void mixAndFilter()
                 yregY[coeffCtr] = yregY[coeffCtr - 1];
             }
         }
-        delayMicroseconds(100);
+        delayMicroseconds(50);
     }
 }

--- a/teensy_lockin.ino
+++ b/teensy_lockin.ino
@@ -565,6 +565,6 @@ void mixAndFilter()
                 yregY[coeffCtr] = yregY[coeffCtr - 1];
             }
         }
-        delayMicroseconds(100);
+        delayMicroseconds(150);
     }
 }

--- a/teensy_lockin.ino
+++ b/teensy_lockin.ino
@@ -87,6 +87,7 @@ void setup()
     // put your setup code here, to run once:
     Serial.begin(38400);
     
+    //pinMode(LED_BUILTIN, OUTPUT);
     #if defined(ARDUINO_TEENSY35)
         pinMode(pinP, INPUT);
         pinMode(pinN, INPUT);
@@ -116,6 +117,9 @@ void setup()
     } // wait for instruction to be sent
     char receivedChar;
     int index = 0;
+
+    int maxWait = 0;
+
     while (Serial.available() && receivedChar != "F")
     {
         receivedChar = Serial.read();
@@ -157,15 +161,33 @@ void setup()
     if (nPts > maxPts){
         nPts = maxPts;
     }
-    delay(1000);
+ 
     measureLockIn();
+
+    // Need to wait until host computer is able to read transmitted data
+    // Set a max waiting time
+    // Reset if max waiting time exceeded OR host signals successful read
+
     if (fastMode == 1){
-        delay(2000);
+      maxWait = 5000;
     }
     else{
-        delay((nPts / 2) + 2000); //unsure if this will be too fast at low nPts - ideally have function that converts nPts to time
-        // - need measurement of how fast teensy writes compared to how fast pc reads
+      maxWait = nPts + 5000;
     }
+
+    index = 0;
+    elapsedMillis transmit_wait;
+
+    while (transmit_wait < maxWait){
+      if (Serial.available()) {
+        receivedChar = Serial.read();
+      }
+      
+      if (receivedChar == 'X') {
+          break;
+      }
+    }
+    
     WRITE_RESTART(0x5FA0004);
 }
 

--- a/teensy_lockin_gui.py
+++ b/teensy_lockin_gui.py
@@ -564,7 +564,9 @@ class LockInDetection(tk.Frame):
              ('Text Document', '*.txt')]
         f = filedialog.asksaveasfile(mode = 'w', filetypes = files, defaultextension = files)
         try:
-            f.write(self.DataDf.to_csv())
+            out_df = self.DataDf.copy()
+            out_df['R'] = 2*out_df['R']
+            f.write(out_df.to_csv())
             print("file saved")
         except:
             pass

--- a/teensy_lockin_gui.py
+++ b/teensy_lockin_gui.py
@@ -439,6 +439,10 @@ class LockInDetection(tk.Frame):
                 if (time.time()-start > 30): #prevent infinite loop
                     break
             d = d.split(',')
+
+            # Tell Teensy to reset itself
+            self.ser.write(str("DRX").encode('utf-8'))
+
             if self.teensyModel.get() == 'T40':
                 print("Average Amplitude:", str(float(d[0]) * 2 * 3.3/1023))
             else:
@@ -494,6 +498,10 @@ class LockInDetection(tk.Frame):
                     break
             data = data[:-1] #cutout last data point since is not actual data
             print("lines read:", len(data))
+
+            # Send a string "data recieved" to tell Teensy to reset
+            self.ser.write(str("DRX").encode('utf-8'))
+
             data2D = []
             for i in range(len(data)): #convert from bytes to floats for each data point
                 try:


### PR DESCRIPTION
Closes #5 ; when saving data to a text file, the amplitude (and not half the amplitude) is saved. (This breaks backwards compatability with old results.)

In addition, fix two significant issues with USB communication and timing that cropped up under testing in Windows:

- GUI now signals (over serial) when it has finished transferring data. When the Teensy receives this signal (or after a suitably long timeout), it restarts. Previously, restarting would sometimes happen a few seconds after the data transfer, causing errors if a user started a new measurement before the restart.

- Slightly lengthened the write delay on the Teensy side, which seems to reduce errors in which data was getting dropped.
